### PR TITLE
 pyinterp v0.11.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,17 +8,29 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_numpy1.18python3.7.____cpython:
-        CONFIG: osx_64_numpy1.18python3.7.____cpython
+      osx_64_blasmklnumpy1.18python3.7.____cpython:
+        CONFIG: osx_64_blasmklnumpy1.18python3.7.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.18python3.8.____cpython:
-        CONFIG: osx_64_numpy1.18python3.8.____cpython
+      osx_64_blasmklnumpy1.18python3.8.____cpython:
+        CONFIG: osx_64_blasmklnumpy1.18python3.8.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.19python3.9.____cpython:
-        CONFIG: osx_64_numpy1.19python3.9.____cpython
+      osx_64_blasmklnumpy1.19python3.9.____cpython:
+        CONFIG: osx_64_blasmklnumpy1.19python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.21python3.10.____cpython:
-        CONFIG: osx_64_numpy1.21python3.10.____cpython
+      osx_64_blasmklnumpy1.21python3.10.____cpython:
+        CONFIG: osx_64_blasmklnumpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_blasopenblasnumpy1.18python3.7.____cpython:
+        CONFIG: osx_64_blasopenblasnumpy1.18python3.7.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_blasopenblasnumpy1.18python3.8.____cpython:
+        CONFIG: osx_64_blasopenblasnumpy1.18python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_blasopenblasnumpy1.19python3.9.____cpython:
+        CONFIG: osx_64_blasopenblasnumpy1.19python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_blasopenblasnumpy1.21python3.10.____cpython:
+        CONFIG: osx_64_blasopenblasnumpy1.21python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/osx_64_blasmklnumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_blasmklnumpy1.18python3.7.____cpython.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+blas:
+- mkl
+boost_cpp:
+- 1.77.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+llvm_openmp:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mkl:
+- '2021'
+numpy:
+- '1.18'
+openblas:
+- 0.3.*
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_blasmklnumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_blasmklnumpy1.18python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 blas:
-- openblas
+- mkl
 boost_cpp:
 - 1.77.0
 channel_sources:
@@ -11,6 +11,8 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
+- '11'
+llvm_openmp:
 - '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blasmklnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blasmklnumpy1.19python3.9.____cpython.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+blas:
+- mkl
+boost_cpp:
+- 1.77.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+llvm_openmp:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mkl:
+- '2021'
+numpy:
+- '1.19'
+openblas:
+- 0.3.*
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_blasmklnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blasmklnumpy1.21python3.10.____cpython.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+blas:
+- mkl
+boost_cpp:
+- 1.77.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+llvm_openmp:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mkl:
+- '2021'
+numpy:
+- '1.21'
+openblas:
+- 0.3.*
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_blasopenblasnumpy1.18python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_blasopenblasnumpy1.18python3.7.____cpython.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+blas:
+- openblas
+boost_cpp:
+- 1.77.0
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '11'
+llvm_openmp:
+- '11'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+mkl:
+- '2021'
+numpy:
+- '1.18'
+openblas:
+- 0.3.*
+pin_run_as_build:
+  boost-cpp:
+    max_pin: x.x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.7.* *_cpython
+target_platform:
+- osx-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_blasopenblasnumpy1.18python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_blasopenblasnumpy1.18python3.8.____cpython.yaml
@@ -12,12 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mkl:
 - '2021'
 numpy:
-- '1.19'
+- '1.18'
 openblas:
 - 0.3.*
 pin_run_as_build:
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blasopenblasnumpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_blasopenblasnumpy1.19python3.9.____cpython.yaml
@@ -12,12 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mkl:
 - '2021'
 numpy:
-- '1.21'
+- '1.19'
 openblas:
 - 0.3.*
 pin_run_as_build:
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.10.* *_cpython
+- 3.9.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_blasopenblasnumpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_blasopenblasnumpy1.21python3.10.____cpython.yaml
@@ -12,12 +12,14 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mkl:
 - '2021'
 numpy:
-- '1.18'
+- '1.21'
 openblas:
 - 0.3.*
 pin_run_as_build:
@@ -27,7 +29,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.10.* *_cpython
 target_platform:
 - osx-64
 zip_keys:

--- a/README.md
+++ b/README.md
@@ -93,31 +93,59 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.18python3.7.____cpython</td>
+              <td>osx_64_blasmklnumpy1.18python3.7.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.7.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasmklnumpy1.18python3.7.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.18python3.8.____cpython</td>
+              <td>osx_64_blasmklnumpy1.18python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.18python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasmklnumpy1.18python3.8.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.19python3.9.____cpython</td>
+              <td>osx_64_blasmklnumpy1.19python3.9.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.19python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasmklnumpy1.19python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.21python3.10.____cpython</td>
+              <td>osx_64_blasmklnumpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_numpy1.21python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasmklnumpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blasopenblasnumpy1.18python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasopenblasnumpy1.18python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blasopenblasnumpy1.18python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasopenblasnumpy1.18python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blasopenblasnumpy1.19python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasopenblasnumpy1.19python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_blasopenblasnumpy1.21python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7861&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyinterp-feedstock?branchName=master&jobName=osx&configuration=osx_64_blasopenblasnumpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 blas:
   - openblas
-  - mkl  # [linux or win]
+  - mkl
 
 gsl:
   - 2.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyinterp" %}
-{% set version = "0.10.0" %}
+{% set version = "0.11.0" %}
 {% set build = 0 %}
 
 # recipe-lint fails if blas is undefined
@@ -16,7 +16,7 @@ package:
 
 source:
   url: https://github.com/CNES/pangeo-{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 326088e78802559ce5676544974f536d12d2e063f8916e39ca1b6bc7de561e03
+  sha256: 9678833299a2a3db9b9d5506f4b4fa9de9382bc7735bd0294e2045b8769c222b
 
 build:
   {% if blas == "openblas" %}


### PR DESCRIPTION
Updated to [v0.11.0](https://github.com/CNES/pangeo-pyinterp/releases/tag/0.11.0)